### PR TITLE
Fix Gtk error

### DIFF
--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -822,7 +822,6 @@ Gtk::Widget *Preferences::getColorManPanel()
             ++row;
         }
     } else {
-        gmonitor->attach(*mplabel, 0, row, 1, 1);
         gmonitor->attach(*monProfile, 1, row, 1, 1);
         ++row;
         gmonitor->attach(*cbAutoMonProfile, 1, row, 1, 1);


### PR DESCRIPTION
Object already attached

Error was:
(ART:74528): Gtk-CRITICAL **: 19:44:58.314: gtk_grid_attach: assertion '_gtk_widget_get_parent (child) == NULL' failed